### PR TITLE
Add chainId to Fireblocks config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ module.exports = {
         privateKey: process.env.FIREBLOCKS_API_PRIVATE_KEY_PATH,
         apiKey: process.env.FIREBLOCKS_API_KEY,
         vaultAccountIds: process.env.FIREBLOCKS_VAULT_ACCOUNT_IDS,
+        chainId: 3,
       }
     },
   },


### PR DESCRIPTION
Without providing the `chainId` property to the plugin config, the Fireblocks Web3 Provider seems to make an illegal RPC request (from Infura logs, an unsupported method `test`). I suspect this needs to be fixed either in the provider or Hardhat plugin code, but manually specifying `chainId` seems a suitable workaround.

```
Error Unavailable HTTP RPC url at [URL]
```